### PR TITLE
migrate : three.js r168

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@masatomakino/gulptask-demo-page": "^0.8.3",
+        "@masatomakino/threejs-shader-materials": "^0.10.0",
         "@tweenjs/tween.js": "^21.0.0",
-        "@types/three": "^0.165.0",
+        "@types/three": "^0.168.0",
         "browser-sync": "^3.0.2",
         "hls.js": "^1.5.1",
         "lil-gui": "^0.19.1",
@@ -19,9 +20,8 @@
         "prettier": "^2.7.1",
         "pretty-quick": "^3.1.3",
         "simple-git-hooks": "^2.8.1",
-        "three": "^0.165.0",
+        "three": "^0.168.0",
         "three-nebula": "^10.0.3",
-        "threejs-shader-materials": "git+https://github.com/MasatoMakino/threejs-shader-materials.git",
         "ts-loader": "^9.5.1",
         "typescript": "^5.3.3",
         "webpack-glsl-loader": "^1.0.1"
@@ -1792,13 +1792,23 @@
       }
     },
     "node_modules/@masatomakino/raf-ticker": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@masatomakino/raf-ticker/-/raf-ticker-0.6.0.tgz",
-      "integrity": "sha512-bcDVh9ecc2c8q/kmQixDC/j+KbKUEuVWHcZ/ihYXGWWZ7KR5nyk6+K8Z1gQSZnU+3+lh8ZvQSUkh07L6O2TCwQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@masatomakino/raf-ticker/-/raf-ticker-0.6.2.tgz",
+      "integrity": "sha512-TOtsroo90bvQ3gnLX70dsn+L4EOwyiSCARVrbm0tEScOimhHqmU1tyWI7mcJa1a20A6dfQj3RBKmM1/JIj3i7Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@masatomakino/threejs-shader-materials": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@masatomakino/threejs-shader-materials/-/threejs-shader-materials-0.10.0.tgz",
+      "integrity": "sha512-mQQ/M1cUpNcxw1Dbh1x+MA/Xq8mJZQ8DpROlz9d5LLHuyaDGwATWnLDeUzlTzOAWNQoJz0Q39AcZirK0APTNrg==",
+      "dev": true,
+      "peerDependencies": {
+        "@masatomakino/raf-ticker": "0.5.3 - 0.6.x",
+        "three": "0.168.0 - 0.168.x"
       }
     },
     "node_modules/@pixi/accessibility": {
@@ -2278,22 +2288,23 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-AJK8JZAFNBF0kBXiAIl5pggYlzAGGA8geVYQXAcPCEDRbyA+oEjkpUBcJJrtNz6IiALwzGexFJGZG2yV3WsYBw==",
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
       "dev": true,
       "dependencies": {
-        "@tweenjs/tween.js": "~23.1.1",
+        "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
+        "@webgpu/types": "*",
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/three/node_modules/@tweenjs/tween.js": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.2.tgz",
-      "integrity": "sha512-kMCNaZCJugWI86xiEHaY338CU5JpD0B97p1j1IKNn/Zto8PgACjQx0UxbHjmOcLl/dDOBnItwD07KmCs75pxtQ==",
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true
     },
     "node_modules/@types/webxr": {
@@ -2447,6 +2458,12 @@
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.44.tgz",
+      "integrity": "sha512-JDpYJN5E/asw84LTYhKyvPpxGnD+bAKPtpW9Ilurf7cZpxaTbxkQcGwOd7jgB9BPBrTYQ+32ufo4HiuomTjHNQ==",
+      "dev": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -6170,9 +6187,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
       "dev": true
     },
     "node_modules/three-nebula": {
@@ -6187,16 +6204,6 @@
       },
       "peerDependencies": {
         "three": ">=0.122.0 <1.0.0"
-      }
-    },
-    "node_modules/threejs-shader-materials": {
-      "version": "0.7.0",
-      "resolved": "git+ssh://git@github.com/MasatoMakino/threejs-shader-materials.git#df7faa53b88ceedf0dae2df89f8326e443bff7f7",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@masatomakino/raf-ticker": "0.5.3 - 0.6.x",
-        "three": "0.163.0 - 0.165.x"
       }
     },
     "node_modules/to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "license": "MIT",
   "devDependencies": {
     "@masatomakino/gulptask-demo-page": "^0.8.3",
+    "@masatomakino/threejs-shader-materials": "^0.10.0",
     "@tweenjs/tween.js": "^21.0.0",
-    "@types/three": "^0.165.0",
+    "@types/three": "^0.168.0",
     "browser-sync": "^3.0.2",
     "hls.js": "^1.5.1",
     "lil-gui": "^0.19.1",
@@ -16,9 +17,8 @@
     "prettier": "^2.7.1",
     "pretty-quick": "^3.1.3",
     "simple-git-hooks": "^2.8.1",
-    "three": "^0.165.0",
+    "three": "^0.168.0",
     "three-nebula": "^10.0.3",
-    "threejs-shader-materials": "git+https://github.com/MasatoMakino/threejs-shader-materials.git",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.3",
     "webpack-glsl-loader": "^1.0.1"

--- a/src/Common.ts
+++ b/src/Common.ts
@@ -8,7 +8,7 @@ import {
   WebGLRenderer,
   REVISION,
 } from "three";
-import WebGPURenderer from "three/examples/jsm/renderers/webgpu/WebGPURenderer.js";
+import { WebGPURenderer } from "three/webgpu";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
 export class Common {

--- a/src/CommonWebGPU.ts
+++ b/src/CommonWebGPU.ts
@@ -1,13 +1,13 @@
 import {
+  WebGPURenderer,
   AmbientLight,
   AxesHelper,
   Camera,
   Color,
   PerspectiveCamera,
   Scene,
-  WebGLRenderer,
   REVISION,
-} from "three";
+} from "three/webgpu";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
 export class Common {
@@ -38,7 +38,7 @@ export class Common {
 
   public static initControl(
     camera: Camera,
-    render: WebGLRenderer
+    render: WebGPURenderer
   ): OrbitControls {
     let domElement;
     if (render) {
@@ -49,14 +49,14 @@ export class Common {
     return control;
   }
 
-  public static initRenderer(
+  public static initWebGPURenderer(
     W: number,
     H: number,
     color: number = 0x000000,
     id: string = "webgl-canvas",
     antialias: boolean = true
   ) {
-    const renderer = new WebGLRenderer({
+    const renderer = new WebGPURenderer({
       canvas: document.getElementById(id) as HTMLCanvasElement,
       antialias: antialias,
     });
@@ -65,7 +65,7 @@ export class Common {
   }
 
   private static initRendererSettings(
-    renderer: WebGLRenderer,
+    renderer: WebGPURenderer,
     color: number,
     W: number,
     H: number
@@ -83,7 +83,7 @@ export class Common {
 
   public static render(
     control: OrbitControls,
-    renderer: WebGLRenderer,
+    renderer: WebGPURenderer,
     scene: Scene,
     camera: Camera,
     onBeforeRender?: () => void
@@ -93,7 +93,7 @@ export class Common {
         onBeforeRender();
       }
       control.update();
-      renderer.render(scene, camera);
+      renderer.renderAsync(scene, camera);
       requestAnimationFrame(rendering);
     };
     rendering();

--- a/src/StudyColorSpace.ts
+++ b/src/StudyColorSpace.ts
@@ -6,7 +6,7 @@ import {
   Color,
   Vector3,
 } from "three";
-import { MeshBasicNodeMaterial, materialColor, uniform } from "three/nodes";
+import { MeshBasicNodeMaterial, materialColor, uniform } from "three/webgpu";
 import { GUI } from "lil-gui";
 
 import { Common } from "./Common";

--- a/src/StudyColorSpace.ts
+++ b/src/StudyColorSpace.ts
@@ -5,11 +5,13 @@ import {
   Scene,
   Color,
   Vector3,
-} from "three";
-import { MeshBasicNodeMaterial, materialColor, uniform } from "three/webgpu";
+  MeshBasicNodeMaterial,
+  materialColor,
+  uniform,
+} from "three/webgpu";
 import { GUI } from "lil-gui";
 
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU";
 
 export class Study {
   public static readonly W = 640;

--- a/src/StudyColorSpaceAlpha.ts
+++ b/src/StudyColorSpaceAlpha.ts
@@ -1,14 +1,15 @@
 import { GUI } from "lil-gui";
+import { WebGLRenderer } from "three";
 import {
   ColorManagement,
   Mesh,
   MeshBasicMaterial,
   PlaneGeometry,
   Scene,
-  WebGLRenderer,
-} from "three";
-import { WebGPURenderer } from "three/webgpu";
-import { Common } from "./Common";
+  WebGPURenderer,
+} from "three/webgpu";
+import { Common } from "./Common.js";
+import { Common as CommonWebGPU } from "./CommonWebGPU.js";
 
 /**
  * WebGLとWebGPUでのopacity値の設定の違いを確認するためのサンプルコード
@@ -22,10 +23,26 @@ export class Study {
   public static readonly W = 640;
   public static readonly H = 480;
 
-  constructor() {
+  static initWebGLScene() {
     const scene = Common.initScene();
     Common.initLight(scene);
     const camera = Common.initCamera(scene, Study.W, Study.H);
+    return { scene, camera };
+  }
+
+  static initWebGPUScene() {
+    const scene = CommonWebGPU.initScene();
+    CommonWebGPU.initLight(scene);
+    const camera = CommonWebGPU.initCamera(scene, Study.W, Study.H);
+    return { scene, camera };
+  }
+
+  constructor() {
+    // const scene = Common.initScene();
+    // Common.initLight(scene);
+    // const camera = Common.initCamera(scene, Study.W, Study.H);
+    const glScnene = Study.initWebGLScene();
+    const wgpuScene = Study.initWebGPUScene();
 
     const canvasGL = document.createElement("canvas");
     canvasGL.id = "webGPU-canvas";
@@ -33,22 +50,23 @@ export class Study {
     document.body.style.display = "flex"; // bodyの子要素を横並びにする
 
     const renderer = Common.initRenderer(Study.W, Study.H, 0x000000);
-    const rendererGPU = Common.initWebGPURenderer(
+    const rendererGPU = CommonWebGPU.initWebGPURenderer(
       Study.W,
       Study.H,
       0x000000,
       "webGPU-canvas"
     );
-    const mat = this.initObject(scene);
+    const matGL = this.initObject(glScnene.scene);
+    const matGPU = this.initObject(wgpuScene.scene);
 
     this.addFigure(renderer.domElement, "WebGL");
     this.addFigure(rendererGPU.domElement, "WebGPU");
 
-    this.initGUI(mat, renderer, rendererGPU);
+    this.initGUI(matGL, matGPU, renderer, rendererGPU);
 
     const rendering = () => {
-      renderer.render(scene, camera);
-      rendererGPU.renderAsync(scene, camera);
+      renderer.render(glScnene.scene, glScnene.camera);
+      rendererGPU.renderAsync(wgpuScene.scene, wgpuScene.camera);
       requestAnimationFrame(rendering);
     };
     rendering();
@@ -82,9 +100,12 @@ export class Study {
 
   initGUI = (
     materialBasic: MeshBasicMaterial,
+    materialBasicWebGPU: MeshBasicMaterial,
     rendererGL: WebGLRenderer,
     rendererWebGPU: WebGPURenderer
   ): void => {
+    const materials = [materialBasic, materialBasicWebGPU];
+
     const gui = new GUI();
     const materialColor = {
       r: 0.5,
@@ -101,11 +122,9 @@ export class Study {
     };
 
     const onChangeColor = () => {
-      materialBasic.color.setRGB(
-        materialColor.r,
-        materialColor.g,
-        materialColor.b
-      );
+      materials.forEach((m) => {
+        m.color.setRGB(materialColor.r, materialColor.g, materialColor.b);
+      });
     };
 
     gui.add(materialColor, "r", 0, 1).onChange(onChangeColor);
@@ -113,7 +132,9 @@ export class Study {
     gui.add(materialColor, "b", 0, 1).onChange(onChangeColor);
 
     const updateAlpha = () => {
-      materialBasic.opacity = materialAlpha.a;
+      materials.forEach((m) => {
+        m.opacity = materialAlpha.a;
+      });
     };
     gui.add(materialAlpha, "a", 0, 1).onChange(updateAlpha);
 

--- a/src/StudyColorSpaceAlpha.ts
+++ b/src/StudyColorSpaceAlpha.ts
@@ -6,9 +6,8 @@ import {
   PlaneGeometry,
   Scene,
   WebGLRenderer,
-  WorkingColorSpace,
 } from "three";
-import WebGPURenderer from "three/examples/jsm/renderers/webgpu/WebGPURenderer.js";
+import { WebGPURenderer } from "three/webgpu";
 import { Common } from "./Common";
 
 /**

--- a/src/StudyNodeMaterial_Attribute.ts
+++ b/src/StudyNodeMaterial_Attribute.ts
@@ -1,9 +1,5 @@
-import { Mesh, PlaneGeometry, Scene, BufferAttribute, Color } from "three";
-import {
-  MeshBasicNodeMaterial,
-  color,
-  attribute,
-} from "three/examples/jsm/nodes/Nodes.js";
+import { Mesh, PlaneGeometry, Scene, BufferAttribute } from "three";
+import { MeshBasicNodeMaterial, color, attribute } from "three/webgpu";
 import { Common } from "./Common";
 
 /**

--- a/src/StudyNodeMaterial_Attribute.ts
+++ b/src/StudyNodeMaterial_Attribute.ts
@@ -1,6 +1,14 @@
-import { Mesh, PlaneGeometry, Scene, BufferAttribute } from "three";
-import { MeshBasicNodeMaterial, color, attribute } from "three/webgpu";
-import { Common } from "./Common";
+import {} from "three";
+import {
+  Mesh,
+  PlaneGeometry,
+  Scene,
+  BufferAttribute,
+  MeshBasicNodeMaterial,
+  color,
+  attribute,
+} from "three/webgpu";
+import { Common } from "./CommonWebGPU";
 
 /**
  * アトリビュートの設定と取り出しのサンプル

--- a/src/StudyNodeMaterial_Basic.ts
+++ b/src/StudyNodeMaterial_Basic.ts
@@ -1,7 +1,12 @@
-import { Mesh, PlaneGeometry, Scene } from "three";
-import { MeshBasicNodeMaterial, color } from "three/webgpu";
+import {
+  Mesh,
+  PlaneGeometry,
+  Scene,
+  MeshBasicNodeMaterial,
+  color,
+} from "three/webgpu";
 
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU";
 
 export class StudyNodeBasic {
   public static readonly W = 640;

--- a/src/StudyNodeMaterial_Basic.ts
+++ b/src/StudyNodeMaterial_Basic.ts
@@ -1,5 +1,5 @@
 import { Mesh, PlaneGeometry, Scene } from "three";
-import { MeshBasicNodeMaterial, color } from "three/nodes";
+import { MeshBasicNodeMaterial, color } from "three/webgpu";
 
 import { Common } from "./Common";
 

--- a/src/StudyNodeMaterial_Bump.ts
+++ b/src/StudyNodeMaterial_Bump.ts
@@ -7,7 +7,7 @@ import {
   vec3,
   ShaderNodeObject,
   UniformNode,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 import { Common } from "./Common";
 import { GUI } from "lil-gui";
 

--- a/src/StudyNodeMaterial_Bump.ts
+++ b/src/StudyNodeMaterial_Bump.ts
@@ -1,5 +1,7 @@
-import { Mesh, Scene, TorusGeometry } from "three";
 import {
+  Mesh,
+  Scene,
+  TorusGeometry,
   MeshBasicNodeMaterial,
   normalLocal,
   positionLocal,
@@ -8,7 +10,7 @@ import {
   ShaderNodeObject,
   UniformNode,
 } from "three/webgpu";
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU";
 import { GUI } from "lil-gui";
 
 export class Study {

--- a/src/StudyNodeMaterial_ColorUniform.ts
+++ b/src/StudyNodeMaterial_ColorUniform.ts
@@ -4,7 +4,7 @@ import {
   ShaderNodeObject,
   UniformNode,
   uniform,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 import { Common } from "./Common";
 import { GUI } from "lil-gui";
 

--- a/src/StudyNodeMaterial_ColorUniform.ts
+++ b/src/StudyNodeMaterial_ColorUniform.ts
@@ -1,11 +1,14 @@
-import { Mesh, PlaneGeometry, Scene, Color } from "three";
 import {
+  Mesh,
+  PlaneGeometry,
+  Scene,
+  Color,
   MeshBasicNodeMaterial,
   ShaderNodeObject,
   UniformNode,
   uniform,
 } from "three/webgpu";
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU.js";
 import { GUI } from "lil-gui";
 
 export class Study {

--- a/src/StudyNodeMaterial_FBM.ts
+++ b/src/StudyNodeMaterial_FBM.ts
@@ -1,11 +1,7 @@
 import { Mesh, PlaneGeometry, Scene } from "three";
-import {
-  MeshBasicNodeMaterial,
-  uniform,
-  uv,
-} from "three/examples/jsm/nodes/Nodes.js";
+import { MeshBasicNodeMaterial, uniform, uv } from "three/webgpu";
 import { Common } from "./Common";
-import { fbm, hash, noise } from "./tsl/FMBFunction";
+import { fbm } from "./tsl/FMBFunction";
 import { GUI } from "lil-gui";
 
 export class StudyNodeBasic {

--- a/src/StudyNodeMaterial_FBM.ts
+++ b/src/StudyNodeMaterial_FBM.ts
@@ -1,6 +1,12 @@
-import { Mesh, PlaneGeometry, Scene } from "three";
-import { MeshBasicNodeMaterial, uniform, uv } from "three/webgpu";
-import { Common } from "./Common";
+import {
+  Mesh,
+  PlaneGeometry,
+  Scene,
+  MeshBasicNodeMaterial,
+  uniform,
+  uv,
+} from "three/webgpu";
+import { Common } from "./CommonWebGPU.js";
 import { fbm } from "./tsl/FMBFunction";
 import { GUI } from "lil-gui";
 

--- a/src/StudyNodeMaterial_MixColor.ts
+++ b/src/StudyNodeMaterial_MixColor.ts
@@ -1,11 +1,14 @@
-import { Mesh, PlaneGeometry, Scene, Color } from "three";
 import {
+  Mesh,
+  PlaneGeometry,
+  Scene,
+  Color,
   MeshBasicNodeMaterial,
   ShaderNodeObject,
   UniformNode,
   uniform,
 } from "three/webgpu";
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU.js";
 import { GUI } from "lil-gui";
 
 export class StudyNodeBasic {

--- a/src/StudyNodeMaterial_MixColor.ts
+++ b/src/StudyNodeMaterial_MixColor.ts
@@ -1,12 +1,10 @@
 import { Mesh, PlaneGeometry, Scene, Color } from "three";
 import {
   MeshBasicNodeMaterial,
-  color,
   ShaderNodeObject,
   UniformNode,
   uniform,
-  materialColor,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 import { Common } from "./Common";
 import { GUI } from "lil-gui";
 

--- a/src/StudyNodeMaterial_Rim.ts
+++ b/src/StudyNodeMaterial_Rim.ts
@@ -1,13 +1,17 @@
 import GUI from "lil-gui";
-import { Color, Mesh, Scene, TorusGeometry, Vector3 } from "three";
 import {
+  Color,
+  Mesh,
+  Scene,
+  TorusGeometry,
+  Vector3,
   MeshBasicNodeMaterial,
   ShaderNodeObject,
   UniformNode,
   materialColor,
   uniform,
 } from "three/webgpu";
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU.js";
 import { rimEffect } from "./tsl/RimFunction.js";
 
 type UniformType<T> = ShaderNodeObject<UniformNode<T>>;

--- a/src/StudyNodeMaterial_Rim.ts
+++ b/src/StudyNodeMaterial_Rim.ts
@@ -6,7 +6,7 @@ import {
   UniformNode,
   materialColor,
   uniform,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 import { Common } from "./Common";
 import { rimEffect } from "./tsl/RimFunction.js";
 

--- a/src/StudyNodeMaterial_RimMultiple.ts
+++ b/src/StudyNodeMaterial_RimMultiple.ts
@@ -1,13 +1,17 @@
 import GUI from "lil-gui";
-import { Color, Mesh, Scene, TorusGeometry, Vector3 } from "three";
 import {
+  Color,
+  Mesh,
+  Scene,
+  TorusGeometry,
+  Vector3,
   MeshBasicNodeMaterial,
   ShaderNodeObject,
   UniformNode,
   materialColor,
   uniform,
 } from "three/webgpu";
-import { Common } from "./Common";
+import { Common } from "./CommonWebGPU.js";
 import { rimAngleEffect } from "./tsl/RimFunction.js";
 
 type UniformType<T> = ShaderNodeObject<UniformNode<T>>;

--- a/src/StudyNodeMaterial_RimMultiple.ts
+++ b/src/StudyNodeMaterial_RimMultiple.ts
@@ -6,7 +6,7 @@ import {
   UniformNode,
   materialColor,
   uniform,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 import { Common } from "./Common";
 import { rimAngleEffect } from "./tsl/RimFunction.js";
 

--- a/src/tsl/FMBFunction.ts
+++ b/src/tsl/FMBFunction.ts
@@ -1,6 +1,3 @@
-// Three.js Transpiler r165
-
-import { Vec2 } from "three";
 import {
   float,
   vec2,
@@ -10,16 +7,16 @@ import {
   abs,
   add,
   fract,
-  tslFn,
+  Fn,
   sub,
   floor,
   mix,
   ShaderNodeObject,
   AttributeNode,
   UniformNode,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 
-const hash = tslFn(([p_immutable, hashLoop_immutable]: [any, any]) => {
+const hash = Fn(([p_immutable, hashLoop_immutable]: [any, any]) => {
   const hashLoop = float(hashLoop_immutable).toVar();
   const p = vec2(p_immutable).toVar();
   p.assign(mod(p, hashLoop));
@@ -34,7 +31,7 @@ const hash = tslFn(([p_immutable, hashLoop_immutable]: [any, any]) => {
   );
 });
 
-const noise = tslFn(([p_immutable, hashLoop_immutable]) => {
+const noise = Fn(([p_immutable, hashLoop_immutable]) => {
   const hashLoop = float(hashLoop_immutable).toVar();
   const p = vec2(p_immutable).toVar();
   p.mulAssign(hashLoop);
@@ -54,9 +51,9 @@ const noise = tslFn(([p_immutable, hashLoop_immutable]) => {
   );
 });
 
-const fbm = tslFn(
+const fbm = Fn(
   ([p_immutable, hashLoop_immutable, amp_immutable]: [
-    ShaderNodeObject<AttributeNode> | Vec2,
+    ShaderNodeObject<AttributeNode>,
     ShaderNodeObject<UniformNode<number>> | number,
     ShaderNodeObject<UniformNode<number>> | number
   ]) => {

--- a/src/tsl/RimFunction.ts
+++ b/src/tsl/RimFunction.ts
@@ -1,5 +1,3 @@
-// Three.js Transpiler r165
-
 import { Color, Vector3 } from "three";
 import {
   ShaderNodeObject,
@@ -8,13 +6,13 @@ import {
   pow,
   sub,
   transformedNormalView,
-  tslFn,
+  Fn,
   vec3,
-} from "three/examples/jsm/nodes/Nodes.js";
+} from "three/webgpu";
 
 type UniformType<T> = ShaderNodeObject<UniformNode<T>>;
 
-export const rimEffect = tslFn(
+export const rimEffect = Fn(
   ([rimColor, rimPow, rimStrength, insideColor, insidePow, insideStrength]: [
     UniformType<Color>,
     UniformType<number>,
@@ -35,7 +33,7 @@ export const rimEffect = tslFn(
   }
 );
 
-export const rimAngleEffect = tslFn(
+export const rimAngleEffect = Fn(
   ([
     rimColor,
     rimPow,


### PR DESCRIPTION
グローバル変数を共有しているとレンダリングに失敗するため、WebGLRendererとWebGPURendererを参照するデモは分離する。